### PR TITLE
Update exploring.clj

### DIFF
--- a/src/examples/exploring.clj
+++ b/src/examples/exploring.clj
@@ -54,8 +54,7 @@
 
 ; START: index-filter
 (defn index-filter [pred coll]
-  (when pred 
-    (for [[idx elt] (indexed coll) :when (pred elt)] idx)))
+  (for [[idx elt] (indexed coll) :when (pred elt)] idx))
 ; END: index-filter
 ; START:index-of-any
 (defn index-of-any [pred coll]


### PR DESCRIPTION
line56
(defn index-filter [pred coll]
  (when pred
     (for [[idx elt] (indexed coll) :when (pred elt)] idx)))

I think that 'when' is not necessary. and I've changed like this.

(defn index-filter [pred coll]
  (for [[idx elt] (indexed coll) :when (pred elt)] idx))

please check this out.
If I am wrong. I'd be grateful that If you send me an email.
ssisksl77@gmail.com